### PR TITLE
Fix: Correct frontend dev port from 5174 to 5173 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 DOCKER_COMPOSE = docker-compose
 DOCKER_COMPOSE_DEV = docker-compose -f docker-compose.dev.yml
 FRONTEND_URL = http://localhost:3000
-FRONTEND_DEV_URL = http://localhost:5174
+FRONTEND_DEV_URL = http://localhost:5173
 BACKEND_URL = http://localhost:8000
 
 # Colors for output


### PR DESCRIPTION
## Summary
- Fixed incorrect port number in Makefile for frontend development URL
- Changed from port 5174 to 5173 to match docker-compose.dev.yml configuration

## Problem
The Makefile was displaying `http://localhost:5174` when running `make dev-start`, but the Docker container is actually configured to use port 5173 in docker-compose.dev.yml. This caused confusion as users couldn't access the application at the displayed URL.

## Solution
Updated the `FRONTEND_DEV_URL` variable in the Makefile from port 5174 to 5173 to match the actual Docker configuration.

## Test plan
- [x] Run `make dev-start` 
- [x] Verify the displayed URL shows `http://localhost:5173`
- [x] Confirm the application is accessible at http://localhost:5173

🤖 Generated with [Claude Code](https://claude.ai/code)